### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ MCP Extension to aid you in searching and writing literature reviews
 
 > Check out this [conversation with Claude](https://claude.ai/share/0572fbd9-3ba2-4143-9f7f-5cae205c6d0d) to see what it can do
 
+<a href="https://glama.ai/mcp/servers/@jerpint/paperpal">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jerpint/paperpal/badge" alt="paperpal MCP server" />
+</a>
+
 ## How it works
 
 `paperpal` gives your LLMs access to [arxiv](https://www.arxiv.org) and [Hugging Face papers](https://huggingface.co/papers).


### PR DESCRIPTION
This PR adds a badge for the [paperpal](https://glama.ai/mcp/servers/@jerpint/paperpal) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jerpint/paperpal">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jerpint/paperpal/badge" alt="paperpal MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.